### PR TITLE
Fix compile warnings for Unused lexical arguments

### DIFF
--- a/super-save.el
+++ b/super-save.el
@@ -66,7 +66,7 @@ See `super-save-auto-save-when-idle'."
   (when super-save-auto-save-when-idle
     (run-with-idle-timer super-save-idle-duration t #'super-save-command)))
 
-(defun super-save-command-advice (orig-fun &rest args)
+(defun super-save-command-advice (_orig-fun &rest _args)
   "A simple wrapper around `super-save-command' that's advice-friendly."
   (super-save-command))
 


### PR DESCRIPTION
I am got some warnings when installing via `melpa`: (emacs version `24.5.1`)

```
Compiling file /home/tejas/.emacs.d/.cask/24.5.1/elpa/super-save-20160114.452/super-save.el at Sat Jan 30 22:43:26 2016
Entering directory `/home/tejas/.emacs.d/.cask/24.5.1/elpa/super-save-20160114.452/'
super-save.el:55:1:Warning: Unused lexical argument `args'
super-save.el:55:1:Warning: Unused lexical argument `orig-fun'

```

This PR will fix these warnings.
