### PR TITLE
Fix wrong-number-of-args when trigger function called with 0 args

### DIFF
--- a/super-save.el
+++ b/super-save.el
@@ -64,7 +64,7 @@ See `super-save-auto-save-when-idle'."
 
 (defvar super-save-idle-timer)
 
-(defun super-save-command-advice (_orig-fun &rest _args)
+(defun super-save-command-advice (&rest _args)
   "A simple wrapper around `super-save-command' that's advice-friendly."
   (super-save-command))
 


### PR DESCRIPTION
This manifested in spacemacs when using, for example, `SPC w
l` (`evil-window-right`), because that calls `windmove-right` with no
arguments. This caused a wrong-number-of-arguments error because
`super-save-command-advice` required at least one argument.
