### PR TITLE
Add a feature to exclude specific buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ You can turn off `super-save` for remote files like this:
 (setq super-save-remote-files nil)
 ```
 
+Sometimes you might want to exclude specific files from super-save. You can
+achieve this via `super-save-exclude`, for example:
+
+``` el
+(setq super-save-exclude '(".gpg"))
+```
+
 ## License
 
 Copyright © 2015-2018 Bozhidar Batsov and [contributors][].

--- a/super-save.el
+++ b/super-save.el
@@ -71,12 +71,31 @@ See `super-save-auto-save-when-idle'."
   :type 'boolean
   :package-version '(super-save . "0.3.0"))
 
+(defcustom super-save-exclude nil
+    "A list of regexps for buffer-file-name excluded from super-save.
+When a buffer-file-name matches any of the regexps it is ignored."
+  :group 'super-save
+  :type '(repeat (choice regexp))
+  :package-version '(super-save . "0.4.0"))
+
+(defun super-save-include-p (filename)
+  "Return non-nil if FILENAME doesn't match any of the `super-save-exclude'."
+  (let ((checks super-save-exclude)
+        (keepit t))
+    (while (and checks keepit)
+      (setq keepit (not (ignore-errors
+                          (if (stringp (car checks))
+                              (string-match (car checks) filename))))
+            checks (cdr checks)))
+    keepit))
+
 (defun super-save-command ()
   "Save the current buffer if needed."
   (when (and buffer-file-name
              (buffer-modified-p (current-buffer))
              (file-writable-p buffer-file-name)
-             (if (file-remote-p buffer-file-name) super-save-remote-files t))
+             (if (file-remote-p buffer-file-name) super-save-remote-files t)
+             (super-save-include-p buffer-file-name))
     (save-buffer)))
 
 (defvar super-save-idle-timer)


### PR DESCRIPTION
This will FIX #25

`super-save-include-p` inspired from [recentf-include-p](https://github.com/emacs-mirror/emacs/blob/883438ef67cb483f5d986651110bbc0578683a82/lisp/recentf.el#L405)