### PR TITLE
Add check of buffer-size and `super-save-predicates` for flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ achieve this via `super-save-exclude`, for example:
 (setq super-save-exclude '(".gpg"))
 ```
 
+You can add predicate to `super-save-predicates`, this predicates must not take arguments and return nil, when current buffer shouldn't save. If predicate don't know needle of save file, then predicate must return t. Folowing example stop `super-save`, when current file in Markdown mode:
+```elisp
+(add-to-list 'super-save-predicates (lambda ()
+                                        (not (eq major-mode 'markdown-mode))))
+```
+
 ## License
 
 Copyright © 2015-2020 Bozhidar Batsov and [contributors][].

--- a/super-save.el
+++ b/super-save.el
@@ -31,9 +31,9 @@
 ;;
 ;;; Code:
 (defgroup super-save nil
-  "Smart-saving of buffers."
-  :group 'tools
-  :group 'convenience)
+    "Smart-saving of buffers."
+    :group 'tools
+    :group 'convenience)
 
 (defvar super-save-mode-map (make-sparse-keymap)
   "super-save mode's keymap.")
@@ -65,6 +65,7 @@ See `super-save-auto-save-when-idle'."
   :type 'integer
   :package-version '(super-save . "0.2.0"))
 
+
 (defcustom super-save-remote-files t
   "Save remote files when t, ignore them otherwise."
   :group 'super-save
@@ -72,85 +73,115 @@ See `super-save-auto-save-when-idle'."
   :package-version '(super-save . "0.3.0"))
 
 (defcustom super-save-exclude nil
-    "A list of regexps for buffer-file-name excluded from super-save.
+  "A list of regexps for buffer-file-name excluded from super-save.
 When a buffer-file-name matches any of the regexps it is ignored."
   :group 'super-save
   :type '(repeat (choice regexp))
   :package-version '(super-save . "0.4.0"))
 
+(defcustom super-save-max-buffer-size 10000
+  "Maximal Size of buffer, for which super-save work."
+  :group 'super-save
+  :type 'integer
+  :package-version '(super-save . "0.4.0"))
+
+(defcustom super-save-predicates
+  '((lambda () buffer-file-name)
+    (lambda () (buffer-modified-p (current-buffer)))
+    (lambda () (file-writable-p buffer-file-name))
+    (lambda () (< (buffer-size) super-save-max-buffer-size))
+    (lambda ()
+        (if (file-remote-p buffer-file-name)
+            super-save-remote-files t))
+    (lambda () (super-save-include-p buffer-file-name)))
+  "Predicates, which return nil, when current buffer dont't need to save.
+Predicates not take arguments, if predicate.  If predicate don't know about
+need this buffer to super-save or not, then its must return t."
+  :group 'super-save
+  :type 'integer
+  :package-version '(super-save . "0.4.0"))
+
 (defun super-save-include-p (filename)
-  "Return non-nil if FILENAME doesn't match any of the `super-save-exclude'."
-  (let ((checks super-save-exclude)
-        (keepit t))
-    (while (and checks keepit)
-      (setq keepit (not (ignore-errors
-                          (if (stringp (car checks))
-                              (string-match (car checks) filename))))
-            checks (cdr checks)))
-    keepit))
+    "Return non-nil if FILENAME doesn't match any of the `super-save-exclude'."
+    (let ((checks super-save-exclude)
+          (keepit t))
+        (while (and checks keepit)
+            (setq keepit (not (ignore-errors
+                                  (if (stringp (car checks))
+                                      (string-match (car checks) filename))))
+                  checks (cdr checks)))
+        keepit))
+
+(defun super-save-p ()
+    "Return nil, when current buffer not need to save.
+Otherwise return t.  This function use variable `super-save-predicates'"
+    (let ((preds super-save-predicates)
+          (save-flag t)
+          current-pred)
+        (while (and save-flag preds)
+            (setq current-pred (car preds))
+            (setq save-flag (funcall current-pred))
+            (setq preds (cdr preds)))
+        save-flag))
 
 (defun super-save-command ()
-  "Save the current buffer if needed."
-  (when (and buffer-file-name
-             (buffer-modified-p (current-buffer))
-             (file-writable-p buffer-file-name)
-             (if (file-remote-p buffer-file-name) super-save-remote-files t)
-             (super-save-include-p buffer-file-name))
-    (save-buffer)))
+    "Save the current buffer if needed."
+    (when (super-save-p)
+        (save-buffer)))
 
 (defvar super-save-idle-timer)
 
 (defun super-save-command-advice (&rest _args)
-  "A simple wrapper around `super-save-command' that's advice-friendly."
-  (super-save-command))
+    "A simple wrapper around `super-save-command' that's advice-friendly."
+    (super-save-command))
 
 (defun super-save-advise-trigger-commands ()
-  "Apply super-save advice to the commands listed in `super-save-triggers'."
-  (mapc (lambda (command)
-          (advice-add command :before #'super-save-command-advice))
-        super-save-triggers))
+    "Apply super-save advice to the commands listed in `super-save-triggers'."
+    (mapc (lambda (command)
+              (advice-add command :before #'super-save-command-advice))
+          super-save-triggers))
 
 (defun super-save-remove-advice-from-trigger-commands ()
-  "Remove super-save advice from to the commands listed in `super-save-triggers'."
-  (mapc (lambda (command)
-          (advice-remove command #'super-save-command-advice))
-        super-save-triggers))
+    "Remove super-save advice from to the commands listed in `super-save-triggers'."
+    (mapc (lambda (command)
+              (advice-remove command #'super-save-command-advice))
+          super-save-triggers))
 
 (defun super-save-initialize-idle-timer ()
-  "Initialize super-save idle timer if `super-save-auto-save-when-idle' is true."
-  (setq super-save-idle-timer
-        (when super-save-auto-save-when-idle
-          (run-with-idle-timer super-save-idle-duration t #'super-save-command))))
+    "Initialize super-save idle timer if `super-save-auto-save-when-idle' is true."
+    (setq super-save-idle-timer
+          (when super-save-auto-save-when-idle
+              (run-with-idle-timer super-save-idle-duration t #'super-save-command))))
 
 (defun super-save-stop-idle-timer ()
-  "Stop super-save idle timer if `super-save-idle-timer' is set."
-  (when super-save-idle-timer
-    (cancel-timer super-save-idle-timer)))
+    "Stop super-save idle timer if `super-save-idle-timer' is set."
+    (when super-save-idle-timer
+        (cancel-timer super-save-idle-timer)))
 
 (defun super-save-initialize ()
-  "Setup super-save's advices and hooks."
-  (super-save-advise-trigger-commands)
-  (super-save-initialize-idle-timer)
-  (dolist (hook super-save-hook-triggers)
-    (add-hook hook #'super-save-command)))
+    "Setup super-save's advices and hooks."
+    (super-save-advise-trigger-commands)
+    (super-save-initialize-idle-timer)
+    (dolist (hook super-save-hook-triggers)
+        (add-hook hook #'super-save-command)))
 
 (defun super-save-stop ()
-  "Cleanup super-save's advices and hooks."
-  (super-save-remove-advice-from-trigger-commands)
-  (super-save-stop-idle-timer)
-  (dolist (hook super-save-hook-triggers)
-    (remove-hook hook #'super-save-command)))
+    "Cleanup super-save's advices and hooks."
+    (super-save-remove-advice-from-trigger-commands)
+    (super-save-stop-idle-timer)
+    (dolist (hook super-save-hook-triggers)
+        (remove-hook hook #'super-save-command)))
 
 ;;;###autoload
 (define-minor-mode super-save-mode
-  "A minor mode that saves your Emacs buffers when they lose focus."
-  :lighter " super-save"
-  :keymap super-save-mode-map
-  :group 'super-save
-  :global t
-  (cond
-   (super-save-mode (super-save-initialize))
-   (t (super-save-stop))))
+    "A minor mode that saves your Emacs buffers when they lose focus."
+    :lighter " super-save"
+    :keymap super-save-mode-map
+    :group 'super-save
+    :global t
+    (cond
+      (super-save-mode (super-save-initialize))
+      (t (super-save-stop))))
 
 (provide 'super-save)
 ;;; super-save.el ends here


### PR DESCRIPTION
I am like `super-save`, but I am often edit large files, and when I am unfocus from buffer with large files, save take a lot of time, but this saves not requires, so I am add check of `buffer-size`, for this I am create more agile system of check on need to save buffers.