### PR TITLE
Add an option to save all buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ deleting trailing white spaces before saving (via Emacs'
 (setq super-save-delete-trailing-whitespaces 'except-current-line)
 ```
 
+By default, `super-save` will automatically save only the current buffer, if you
+want to save all open buffers you can set `super-save-all-buffers` to `t`.
+
 ## License
 
 Copyright © 2015-2022 Bozhidar Batsov and [contributors][].

--- a/changelog.md
+++ b/changelog.md
@@ -4,28 +4,48 @@
 
 ### New features
 
-* Make super-save checks customizable via `super-save-predicates`.
-* Introduce defcustom `super-save-max-buffer-size` as a way to avoid auto-saving big files.
-* Introduce defcustom `super-save-exclude` (a list of regular expression) as a way to filter out certain buffer names from being auto-saved.
+- Make super-save checks customizable via `super-save-predicates`.
+- Introduce defcustom `super-save-max-buffer-size` as a way to avoid auto-saving
+  big files.
+- Introduce defcustom `super-save-exclude` (a list of regular expression) as a
+  way to filter out certain buffer names from being auto-saved.
+- [#43](https://github.com/bbatsov/crux/issues/43) Introduce `super-save-silent`
+  to avoid printing messages in the `*Messages*` buffer or in the echo area.
+- [#43](https://github.com/bbatsov/crux/issues/43) Introduce
+  `super-save-delete-trailing-whitespaces` which defaults to `nil` and accepts
+  `t` to run `delete-trailing-whitespace` before saving the buffer. This
+  variable accepts only the symbol `except-current-line` to delete trailing
+  white spaces from all lines except the current one. This can be useful when we
+  are in the middle of writing some thing and we add a space at the end, in this
+  case, we more likely need the space to stay there instead of deleting it.
+- [#44](https://github.com/bbatsov/crux/issues/44) &
+  [#20](https://github.com/bbatsov/crux/issues/20) Introduce
+  `super-save-all-buffers` to save all modified buffers instead of only the
+  current one.
+
 
 ## 0.3.0 (2018-09-29)
 
 ### New features
 
-* [#16](https://github.com/bbatsov/crux/issues/16): Make this of hook triggers customizable (see `super-save-hook-triggers`).
-* [#18](https://github.com/bbatsov/crux/issues/18): Make it possible to disable super-save for remote files (see `super-save-remote-files`).
+- [#16](https://github.com/bbatsov/crux/issues/16): Make this of hook triggers
+  customizable (see `super-save-hook-triggers`).
+- [#18](https://github.com/bbatsov/crux/issues/18): Make it possible to disable
+  super-save for remote files (see `super-save-remote-files`).
 
 ### Changes
 
-* Make `super-save-triggers` a list of symbols (it used to be a list of strings).
-* Trigger super-save on `next-buffer` and `previous-buffer`.
+- Make `super-save-triggers` a list of symbols (it used to be a list of strings).
+- Trigger super-save on `next-buffer` and `previous-buffer`.
 
 ## 0.2.0 (2016-02-21)
 
 ### New features
 
-* [#3](https://github.com/bbatsov/crux/issues/3): Turn super-save into a global minor-mode (`super-save-mode`).
-* Add some functionality for auto-saving buffers when Emacs is idle (disabled by default).
+- [#3](https://github.com/bbatsov/crux/issues/3): Turn super-save into a global
+  minor-mode (`super-save-mode`).
+- Add some functionality for auto-saving buffers when Emacs is idle (disabled by
+  default).
 
 ## 0.1.0 (2016-02-11)
 

--- a/super-save.el
+++ b/super-save.el
@@ -62,6 +62,12 @@
   :type 'boolean
   :package-version '(super-save . "0.2.0"))
 
+(defcustom super-save-all-buffers nil
+  "Auto-save all buffers, not just the current one."
+  :group 'super-save
+  :type 'boolean
+  :package-version '(super-save . "0.4.0"))
+
 (defcustom super-save-idle-duration 5
   "The number of seconds Emacs has to be idle, before auto-saving the current buffer.
 See `super-save-auto-save-when-idle'."
@@ -150,15 +156,17 @@ This function relies on the variable `super-save-predicates'."
 
 (defun super-save-command ()
   "Save the current buffer if needed."
-  (when (super-save-p)
-    (super-save-delete-trailing-whitespaces-maybe)
-    (if super-save-silent
-        (with-temp-message ""
-          (let ((inhibit-message t)
-                (inhibit-redisplay t)
-                (message-log-max nil))
-            (basic-save-buffer)))
-      (basic-save-buffer))))
+  (dolist (buf (if super-save-all-buffers (buffer-list) (list (current-buffer))))
+    (with-current-buffer buf
+      (when (super-save-p)
+        (super-save-delete-trailing-whitespaces-maybe)
+        (if super-save-silent
+            (with-temp-message ""
+              (let ((inhibit-message t)
+                    (inhibit-redisplay t)
+                    (message-log-max nil))
+                (basic-save-buffer)))
+          (basic-save-buffer))))))
 
 (defvar super-save-idle-timer)
 


### PR DESCRIPTION
This PR adds an option to save all buffers (not only the current one), it fixes #19 (it is a rewrite of #20). **It defaults to `nil`**, so it won't change the workflow unless explicitly enabled.

As I've said in a previous comment on https://github.com/bbatsov/super-save/issues/19#issuecomment-1846924352, it makes sense to provide this feature.

> @bbatsov I've implemented but not pushed this feature (to save all buffers). I found out that @cireu have already implemented it.
> 
> I can confirm that having an option to save all buffers can be interesting, specially when doing indirect buffer edits (like when editing `grep`s with `occur-mode` and `occur-edit-mode`, or when running a project-wide search and replace `project-query-replace-regexp`, etc.). In these cases, we can indirectly edit several buffers without actually visiting or switching to these buffers.
> 
> I've implemented the feature (which defaults to `nil`, so I would keep the current workflow intact) in the new code base. I can open a PR or add it to the currently opened one.
> 
> Thanks again for this package.

What do you think @bbatsov?

---

Merging this should close #19 and #20.